### PR TITLE
Add tag filtering support and analytics stub

### DIFF
--- a/VERIFICATION_CHECKLIST.md
+++ b/VERIFICATION_CHECKLIST.md
@@ -1,0 +1,13 @@
+# Verification Checklist
+
+- [ ] GitHub Pages build is enabled
+- [ ] Home page renders correctly
+- [ ] Posts page renders correctly
+- [ ] Recipes page renders correctly
+- [ ] About page renders correctly
+- [ ] Recipe filters work and URL updates with selections
+- [ ] SEO tags are present on key pages
+- [ ] Feed available at `/feed.xml`
+- [ ] Sitemap available at `/sitemap.xml`
+- [ ] Custom 404 page renders
+- [ ] Lighthouse scores meet ≥95 targets

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,1 @@
+<!-- Add your analytics snippet here when analytics is enabled. -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,5 +10,8 @@
       {{ content }}
     </main>
     {% include footer.html %}
+    {% if site.analytics_enabled %}
+      {% include analytics.html %}
+    {% endif %}
   </body>
 </html>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Working with Carl">
-  <rect width="64" height="64" rx="14" fill="#c26d1c"/>
-  <path d="M42 19.5c-2.8-3.3-7-5.5-12-5.5-9.9 0-17.5 7.6-17.5 18s7.6 18 17.5 18c5 0 9.2-2.2 12-5.5" fill="none" stroke="#f5ede4" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Working with Carl">
+  <rect width="32" height="32" rx="7" fill="#c26d1c"/>
+  <path d="M8 16c0-4.418 3.582-8 8-8s8 3.582 8 8-3.582 8-8 8" fill="none" stroke="#f5ede4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/posts/index.html
+++ b/posts/index.html
@@ -10,15 +10,33 @@ permalink: /posts/
     <p class="meta">{{ page.description }}</p>
     {% endif %}
   </header>
+  <div class="stack" data-gap="xs" aria-live="polite" data-tag-filter-messages>
+    <p class="meta" data-tag-filter-status hidden></p>
+    <p class="meta" data-tag-filter-empty hidden>No posts found for tag “<span data-tag-filter-tag></span>”.</p>
+  </div>
   {% assign total_posts = site.posts | size %}
-  <ul class="stack" role="list" data-gap="lg">
+  <ul class="stack" role="list" data-gap="lg" data-posts-list>
     {% if paginator and paginator.posts %}
       {% for post in paginator.posts %}
-      <li>{% include post-card.html post=post %}</li>
+      {% capture normalized_tags %}
+        {% if post.tags %}
+          {% for tag in post.tags %}
+            {{ tag | strip | downcase }}{% unless forloop.last %}|{% endunless %}
+          {% endfor %}
+        {% endif %}
+      {% endcapture %}
+      <li data-post-item data-post-tags="{{ normalized_tags | strip }}">{% include post-card.html post=post %}</li>
       {% endfor %}
     {% elsif total_posts > 0 %}
       {% for post in site.posts limit:12 %}
-      <li>{% include post-card.html post=post %}</li>
+      {% capture normalized_tags %}
+        {% if post.tags %}
+          {% for tag in post.tags %}
+            {{ tag | strip | downcase }}{% unless forloop.last %}|{% endunless %}
+          {% endfor %}
+        {% endif %}
+      {% endcapture %}
+      <li data-post-item data-post-tags="{{ normalized_tags | strip }}">{% include post-card.html post=post %}</li>
       {% endfor %}
     {% else %}
     <li>
@@ -33,3 +51,54 @@ permalink: /posts/
   {% endif %}
   {% include pagination.html %}
 </section>
+<script>
+  (function () {
+    const params = new URLSearchParams(window.location.search);
+    const rawTag = params.get('tag');
+    if (!rawTag) {
+      return;
+    }
+
+    const displayTag = rawTag.trim();
+    const normalizedTag = displayTag.toLowerCase();
+    if (!normalizedTag) {
+      return;
+    }
+
+    const items = Array.from(document.querySelectorAll('[data-post-item]'));
+    if (!items.length) {
+      return;
+    }
+
+    let matchCount = 0;
+    items.forEach((item) => {
+      const tags = (item.getAttribute('data-post-tags') || '')
+        .split('|')
+        .map((tag) => tag.trim())
+        .filter(Boolean);
+      const matches = tags.includes(normalizedTag);
+      item.hidden = !matches;
+      if (matches) {
+        matchCount += 1;
+      }
+    });
+
+    const tagNameTargets = document.querySelectorAll('[data-tag-filter-tag]');
+    tagNameTargets.forEach((node) => {
+      node.textContent = displayTag;
+    });
+
+    const status = document.querySelector('[data-tag-filter-status]');
+    if (status) {
+      status.hidden = false;
+      status.textContent = matchCount > 0
+        ? `Filtering posts by tag “${displayTag}”. Showing ${matchCount} ${matchCount === 1 ? 'post' : 'posts'}.`
+        : `Filtering posts by tag “${displayTag}”.`;
+    }
+
+    const emptyState = document.querySelector('[data-tag-filter-empty]');
+    if (emptyState) {
+      emptyState.hidden = matchCount > 0;
+    }
+  }());
+</script>

--- a/tags/index.html
+++ b/tags/index.html
@@ -1,0 +1,86 @@
+---
+layout: default
+title: Tags
+permalink: /tags/
+---
+{% assign tag_entries = '' %}
+{% assign seen_slugs = '' %}
+{% for tag_pair in site.tags %}
+  {% assign tag_name = tag_pair[0] | strip %}
+  {% if tag_name != '' %}
+    {% assign tag_slug = tag_name | downcase %}
+    {% assign slug_marker = '|' | append: tag_slug | append: '|' %}
+    {% unless seen_slugs contains slug_marker %}
+      {% assign seen_slugs = seen_slugs | append: slug_marker %}
+      {% assign tag_entries = tag_entries | append: tag_name | append: '::' | append: tag_slug | append: '|' %}
+    {% endunless %}
+  {% endif %}
+{% endfor %}
+{% for recipe in site.recipes %}
+  {% if recipe.tags %}
+    {% for tag in recipe.tags %}
+      {% assign trimmed_tag = tag | strip %}
+      {% if trimmed_tag != '' %}
+        {% assign tag_slug = trimmed_tag | downcase %}
+        {% assign slug_marker = '|' | append: tag_slug | append: '|' %}
+        {% unless seen_slugs contains slug_marker %}
+          {% assign seen_slugs = seen_slugs | append: slug_marker %}
+          {% assign tag_entries = tag_entries | append: trimmed_tag | append: '::' | append: tag_slug | append: '|' %}
+        {% endunless %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}
+<section class="stack" data-gap="lg" aria-labelledby="tags-title">
+  <header class="stack" data-gap="sm">
+    <h1 id="tags-title">{{ page.title }}</h1>
+    <p class="meta">Browse content by tag across posts and recipes.</p>
+  </header>
+  {% if tag_entries == '' %}
+  <div class="card stack" data-gap="xs">
+    <p class="meta">Tags will appear once posts or recipes include them.</p>
+  </div>
+  {% else %}
+  {% assign all_tags = tag_entries | split: '|' | sort_natural %}
+  <ul class="stack" role="list" data-gap="md">
+    {% for tag in all_tags %}
+      {% assign tag_parts = tag | strip | split: '::' %}
+      {% assign label = tag_parts[0] | strip %}
+      {% assign tag_slug = tag_parts[1] | default: tag_parts[0] | strip | downcase %}
+      {% if label != '' %}
+        {% assign label_downcase = label | downcase %}
+        {% assign post_count = 0 %}
+        {% for post in site.posts %}
+          {% if post.tags %}
+            {% for post_tag in post.tags %}
+              {% if post_tag | downcase == label_downcase %}
+                {% assign post_count = post_count | plus: 1 %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+        {% assign recipe_count = 0 %}
+        {% for recipe in site.recipes %}
+          {% if recipe.tags %}
+            {% for recipe_tag in recipe.tags %}
+              {% if recipe_tag | downcase == label_downcase %}
+                {% assign recipe_count = recipe_count | plus: 1 %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+        {% assign tag_query = tag_slug | uri_escape %}
+        <li class="card stack" data-gap="xs">
+          <h2 class="h3">{{ label }}</h2>
+          <p class="meta">
+            <a href="{{ '/posts/' | relative_url }}?tag={{ tag_query }}">View posts</a>
+            ({{ post_count }}) ·
+            <a href="{{ '/recipes/' | relative_url }}?tags={{ tag_query }}">View recipes</a>
+            ({{ recipe_count }})
+          </p>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+  {% endif %}
+</section>


### PR DESCRIPTION
## Summary
- replace the favicon with a lightweight SVG variant
- add an analytics include that is gated behind the `site.analytics_enabled` flag
- implement tag-aware filtering, a tag index, and a verification checklist for review

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable not available in container)*


------
https://chatgpt.com/codex/tasks/task_e_68d68e5670cc832b972f3025a811f969