### PR TITLE
Fix stylesheet loading by serving precompiled CSS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,3 @@ defaults:
     values:
       layout: recipe
       is_recipe: true
-sass:
-  sass_dir: assets/css
-  style: compressed

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,5 +1,3 @@
----
----
 :root {
   color-scheme: light dark;
   --font-system: 'Inter var', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;


### PR DESCRIPTION
## Summary
- replace the SCSS entry point with a static `assets/css/main.css` file so the stylesheet is available without Jekyll processing
- remove the unused Sass configuration from `_config.yml`

## Testing
- not run (network restrictions prevent installing Ruby gems in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d6911c6f10832b9caefa5bf0aed7a3