### PR TITLE
Adjust pagination hint conditional

### DIFF
--- a/posts/index.html
+++ b/posts/index.html
@@ -46,9 +46,11 @@ permalink: /posts/
     </li>
     {% endif %}
   </ul>
-  {% if not paginator and total_posts > 12 %}
-  <p class="meta">Showing the latest 12 posts. Enable the <code>jekyll-paginate</code> plugin and <code>paginate</code> setting in <code>_config.yml</code> to browse the full archive.</p>
-  {% endif %}
+  {% unless paginator %}
+    {% if total_posts > 12 %}
+    <p class="meta">Showing the latest 12 posts. Enable the <code>jekyll-paginate</code> plugin and <code>paginate</code> setting in <code>_config.yml</code> to browse the full archive.</p>
+    {% endif %}
+  {% endunless %}
   {% include pagination.html %}
 </section>
 <script>


### PR DESCRIPTION
## Summary
- render the pagination setup hint only when the paginator is disabled
- keep the existing 12-post threshold check intact within an `unless paginator` block

## Testing
- ⚠️ `bundle exec jekyll build` *(fails: missing Jekyll executable due to forbidden access when running `bundle install`)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a197d9c0832bb78cc7c40c9a1c8d