### PR TITLE
PR-SR0: Add athlete storage layer and migration scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## [Unreleased]
+### Added
+- Introduced in-memory Dexie-style database with athlete store and session migration defaults to support upcoming live session flow.
+- Added automated tests covering athlete persistence and migration behaviour.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "motion-live",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/storage/athleteStore.js
+++ b/src/storage/athleteStore.js
@@ -1,0 +1,64 @@
+const { randomUUID } = require('crypto');
+const { db } = require('./db');
+
+function currentTimestamp() {
+  return new Date().toISOString();
+}
+
+async function createAthlete(input) {
+  await db.open();
+  const now = currentTimestamp();
+  const athlete = {
+    id: randomUUID(),
+    firstName: input.firstName,
+    lastName: input.lastName,
+    dominantHand: input.dominantHand,
+    birthYear: input.birthYear,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await db.table('athletes').add(athlete);
+  return athlete;
+}
+
+async function updateAthlete(id, updates) {
+  await db.open();
+  const table = db.table('athletes');
+  const existing = await table.get(id);
+  if (!existing) {
+    throw new Error(`Athlete ${id} not found`);
+  }
+
+  const updated = {
+    ...existing,
+    ...updates,
+    updatedAt: currentTimestamp(),
+  };
+
+  await table.put(updated);
+  return updated;
+}
+
+async function getAthlete(id) {
+  await db.open();
+  return db.table('athletes').get(id);
+}
+
+async function getAllAthletes() {
+  await db.open();
+  return db.table('athletes').orderBy('lastName').toArray();
+}
+
+async function deleteAthlete(id) {
+  await db.open();
+  await db.table('athletes').delete(id);
+}
+
+module.exports = {
+  createAthlete,
+  updateAthlete,
+  getAthlete,
+  getAllAthletes,
+  deleteAthlete,
+};

--- a/src/storage/db.js
+++ b/src/storage/db.js
@@ -1,0 +1,159 @@
+class Table {
+  constructor(name) {
+    this.name = name;
+    this.rows = new Map();
+  }
+  async add(value) {
+    this.rows.set(value.id, structuredClone(value));
+    return value.id;
+  }
+  async put(value) {
+    this.rows.set(value.id, structuredClone(value));
+    return value.id;
+  }
+  async get(id) {
+    const item = this.rows.get(id);
+    return item ? structuredClone(item) : undefined;
+  }
+  async delete(id) {
+    this.rows.delete(id);
+  }
+  orderBy(field) {
+    return {
+      toArray: async () =>
+        Array.from(this.rows.values())
+          .map((value) => structuredClone(value))
+          .sort((a, b) => {
+            const left = a[field] ?? '';
+            const right = b[field] ?? '';
+            return String(left).localeCompare(String(right));
+          }),
+    };
+  }
+  toCollection() {
+    return {
+      modify: async (modifier) => {
+        for (const [key, value] of this.rows.entries()) {
+          const clone = structuredClone(value);
+          await modifier(clone);
+          this.rows.set(key, clone);
+        }
+      },
+    };
+  }
+  async clear() {
+    this.rows.clear();
+  }
+}
+
+class Transaction {
+  constructor(tables) {
+    this.tables = tables;
+  }
+  table(name) {
+    const table = this.tables.get(name);
+    if (!table) throw new Error(`Table ${name} is not defined`);
+    return table;
+  }
+}
+
+class Dexie {
+  constructor(name) {
+    this.name = name;
+    this.tables = new Map();
+    this.versions = [];
+    this.opened = false;
+  }
+  version(versionNumber) {
+    const spec = { version: versionNumber, stores: {}, upgrade: undefined };
+    this.versions.push(spec);
+    return {
+      stores: (schema) => {
+        spec.stores = schema;
+        return {
+          upgrade: (upgradeFn) => {
+            spec.upgrade = upgradeFn;
+            return this;
+          },
+        };
+      },
+    };
+  }
+  table(name) {
+    if (!this.tables.has(name)) this.tables.set(name, new Table(name));
+    return this.tables.get(name);
+  }
+  async open() {
+    if (this.opened) return this;
+    this.versions.sort((a, b) => a.version - b.version);
+    for (const spec of this.versions) {
+      Object.keys(spec.stores).forEach((tableName) => {
+        this.table(tableName);
+      });
+      if (spec.upgrade) {
+        const transaction = new Transaction(this.tables);
+        await spec.upgrade(transaction);
+      }
+    }
+    this.opened = true;
+    return this;
+  }
+  async close() {
+    this.opened = false;
+  }
+  async delete() {
+    for (const table of this.tables.values()) {
+      await table.clear();
+    }
+    this.opened = false;
+  }
+}
+
+const DEFAULT_SESSION_OPTIONS = Object.freeze({
+  approachRecordingEnabled: false,
+  defaultPreRollMs: 0,
+  autoAdvanceAthlete: true,
+});
+
+class MotionDatabase extends Dexie {
+  constructor() {
+    super('motion-database');
+
+    const baseSessionFields = 'id, createdAt, updatedAt';
+    const baseAthleteFields = 'id, firstName, lastName';
+
+    this.version(1).stores({
+      athletes: baseAthleteFields,
+      sessions: baseSessionFields,
+    });
+
+    this.version(2)
+      .stores({
+        athletes: `${baseAthleteFields}, dominantHand, birthYear`,
+        sessions: `${baseSessionFields}, title, location`,
+      })
+      .upgrade(async (transaction) => {
+        const sessionsTable = transaction.table('sessions');
+        await sessionsTable.toCollection().modify((session) => {
+          session.participants = session.participants ?? [];
+          session.notes = session.notes ?? '';
+          session.options = session.options ?? { ...DEFAULT_SESSION_OPTIONS };
+        });
+      });
+  }
+}
+
+const db = new MotionDatabase();
+const openPromise = db.open();
+
+async function resetDatabaseForTesting() {
+  await db.delete();
+  await db.open();
+}
+
+module.exports = {
+  db,
+  DEFAULT_SESSION_OPTIONS,
+  resetDatabaseForTesting,
+  openPromise,
+};

--- a/tests/athleteStore.e2e.test.js
+++ b/tests/athleteStore.e2e.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { resetDatabaseForTesting } = require('../src/storage/db');
+const { createAthlete, getAllAthletes } = require('../src/storage/athleteStore');
+
+test.beforeEach(async () => {
+  await resetDatabaseForTesting();
+});
+
+test('roster flow persists and sorts athletes', async () => {
+  await createAthlete({ firstName: 'Alex', lastName: 'Zimmer' });
+  await createAthlete({ firstName: 'Blake', lastName: 'Young' });
+  await createAthlete({ firstName: 'Casey', lastName: 'Adams' });
+
+  const all = await getAllAthletes();
+  assert.deepEqual(
+    all.map((athlete) => athlete.lastName),
+    ['Adams', 'Young', 'Zimmer']
+  );
+});

--- a/tests/athleteStore.test.js
+++ b/tests/athleteStore.test.js
@@ -1,0 +1,41 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { db, DEFAULT_SESSION_OPTIONS, resetDatabaseForTesting } = require('../src/storage/db');
+const { createAthlete, deleteAthlete, getAllAthletes, updateAthlete } = require('../src/storage/athleteStore');
+
+test.beforeEach(async () => {
+  await resetDatabaseForTesting();
+});
+
+test('database migrations hydrate session defaults', async () => {
+  const sessionsTable = db.table('sessions');
+  await sessionsTable.add({
+    id: 'session-legacy',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  });
+
+  await db.close();
+  await db.open();
+  const stored = await sessionsTable.get('session-legacy');
+
+  assert.deepEqual(stored.participants, []);
+  assert.equal(stored.notes, '');
+  assert.deepEqual(stored.options, DEFAULT_SESSION_OPTIONS);
+});
+
+test('athleteStore CRUD flow', async () => {
+  const created = await createAthlete({ firstName: 'Sky', lastName: 'Johnson' });
+  assert.ok(created.id);
+
+  const all = await getAllAthletes();
+  assert.equal(all.length, 1);
+
+  const updated = await updateAthlete(created.id, { lastName: 'Jones' });
+  assert.equal(updated.lastName, 'Jones');
+  assert.notEqual(updated.updatedAt, created.updatedAt);
+
+  await deleteAthlete(created.id);
+  const remaining = await getAllAthletes();
+  assert.equal(remaining.length, 0);
+});


### PR DESCRIPTION
## Summary
- introduce an in-memory Dexie-style database wrapper with session schema upgrades for participants, notes, and options
- add an athlete store with CRUD helpers to back the upcoming roster picker
- cover migrations and roster flows with node:test unit and e2e suites

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da47afe3e8832b9d804ce36cd08b34