### PR TITLE
feat: add viewport-first calibration layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 ### Added
 - Introduced in-memory Dexie-style database with athlete store and session migration defaults to support upcoming live session flow.
 - Added automated tests covering athlete persistence and migration behaviour.
+- Created calibration workspace page with viewport-first grid layout, responsive breakpoints, and supporting styles.

--- a/REPORT-CalibLayout.md
+++ b/REPORT-CalibLayout.md
@@ -1,0 +1,4 @@
+# Calibration Layout Update
+
+- Grid rearranged to prioritize the viewport (≈72%) next to the compact stepper (≈28%) with the filmstrip spanning the full width below.
+- Added responsive breakpoints for tablet and mobile so elements stack without losing emphasis on the viewport-first flow.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -568,3 +568,247 @@ pre {
   min-height: 5.5rem;
   padding-right: 0.3rem;
 }
+
+/* Calibration layout */
+.calibration {
+  display: grid;
+  gap: clamp(1.5rem, 2vw, 2.5rem);
+  padding-block: clamp(2rem, 6vh, 3.5rem);
+}
+
+.calibration__header {
+  display: grid;
+  gap: clamp(0.75rem, 1.4vw, 1rem);
+  max-width: min(72ch, 100%);
+}
+
+.calibration__lede {
+  color: var(--color-muted);
+}
+
+.calibration-layout {
+  display: grid;
+  gap: clamp(1.25rem, 2vw, 2rem);
+  grid-template-columns: minmax(0, 72%) minmax(18rem, 28%);
+  grid-template-areas:
+    'viewport stepper'
+    'filmstrip filmstrip';
+  align-items: start;
+}
+
+.calibration-viewport {
+  grid-area: viewport;
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(1rem, 1.5vw, 1.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.calibration-viewport__frame {
+  aspect-ratio: 16 / 9;
+  background: repeating-linear-gradient(
+      45deg,
+      rgba(194, 109, 28, 0.12),
+      rgba(194, 109, 28, 0.12) 1rem,
+      transparent 1rem,
+      transparent 2rem
+    ),
+    rgba(255, 255, 255, 0.75);
+  border: 1px dashed var(--color-accent);
+  border-radius: calc(var(--radius) * 0.75);
+  display: grid;
+  place-items: center;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.calibration-stepper {
+  grid-area: stepper;
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(1rem, 1.3vw, 1.5rem);
+  display: grid;
+  gap: clamp(0.75rem, 1.2vw, 1.1rem);
+  align-content: start;
+}
+
+.calibration-stepper__title {
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.calibration-stepper__list {
+  display: grid;
+  gap: clamp(0.75rem, 1vw, 1rem);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.calibration-stepper__list li {
+  display: grid;
+  gap: 0.3rem;
+  padding: 0.8rem;
+  border-radius: calc(var(--radius) * 0.75);
+  border: 1px solid rgba(31, 26, 23, 0.08);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.calibration-stepper__list h3 {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.calibration-stepper__controls {
+  display: grid;
+  grid-auto-flow: column;
+  justify-content: start;
+  gap: 0.75rem;
+}
+
+.calibration-stepper__button {
+  appearance: none;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background-color var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.calibration-stepper__button:hover,
+.calibration-stepper__button:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent-strong);
+}
+
+.calibration-stepper__button--primary {
+  background: var(--color-accent);
+  color: var(--color-text);
+  border-color: transparent;
+}
+
+.calibration-stepper__button--primary:hover,
+.calibration-stepper__button--primary:focus-visible {
+  background: var(--color-accent-strong);
+}
+
+.calibration-filmstrip {
+  grid-area: filmstrip;
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(1rem, 1.5vw, 1.75rem);
+  display: grid;
+  gap: clamp(0.75rem, 1vw, 1.25rem);
+}
+
+.calibration-filmstrip__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem 1rem;
+}
+
+.calibration-filmstrip__title {
+  font-size: 1.1rem;
+}
+
+.calibration-filmstrip__hint {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.calibration-filmstrip__scroller {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(6rem, 8.5rem);
+  gap: clamp(0.75rem, 1vw, 1.25rem);
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+  scrollbar-width: thin;
+}
+
+.calibration-filmstrip__scroller::-webkit-scrollbar {
+  height: 0.4rem;
+}
+
+.calibration-filmstrip__scroller::-webkit-scrollbar-thumb {
+  background: rgba(31, 26, 23, 0.25);
+  border-radius: 999px;
+}
+
+.calibration-filmstrip__frame {
+  position: relative;
+  appearance: none;
+  border: 1px solid rgba(31, 26, 23, 0.1);
+  border-radius: calc(var(--radius) * 0.75);
+  padding: 0.6rem;
+  background: rgba(255, 255, 255, 0.9);
+  color: inherit;
+  font: inherit;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color var(--transition), box-shadow var(--transition), color var(--transition);
+}
+
+.calibration-filmstrip__frame:hover,
+.calibration-filmstrip__frame:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent-strong);
+}
+
+.calibration-filmstrip__frame--active {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 0.2rem rgba(194, 109, 28, 0.15);
+}
+
+@media (max-width: 1100px) {
+  .calibration-layout {
+    grid-template-columns: minmax(0, 70%) minmax(16rem, 30%);
+  }
+}
+
+@media (max-width: 900px) {
+  .calibration-layout {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      'viewport'
+      'filmstrip'
+      'stepper';
+  }
+
+  .calibration-filmstrip {
+    order: 1;
+  }
+
+  .calibration-stepper__controls {
+    grid-auto-flow: row;
+    justify-items: stretch;
+  }
+
+  .calibration-stepper__button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .calibration {
+    padding-block: clamp(1.5rem, 5vh, 2.5rem);
+  }
+
+  .calibration-viewport__frame {
+    font-size: 0.85rem;
+  }
+}

--- a/calibration/index.html
+++ b/calibration/index.html
@@ -1,0 +1,56 @@
+---
+layout: default
+title: Calibration Capture
+description: Viewport-first calibration workspace with viewport, stepper, and filmstrip layout.
+permalink: /calibration/
+---
+
+<section class="calibration" aria-labelledby="calibration-heading">
+  <header class="calibration__header">
+    <h1 id="calibration-heading">Calibration workspace</h1>
+    <p class="calibration__lede">
+      Align the capture viewport, review the compact stepper, and manage saved frames in the filmstrip below.
+    </p>
+  </header>
+  <div class="calibration-layout" role="application" aria-describedby="calibration-heading">
+    <section class="calibration-viewport" aria-label="Viewport preview">
+      <div class="calibration-viewport__frame">
+        <p>Viewport preview placeholder</p>
+      </div>
+    </section>
+    <aside class="calibration-stepper" aria-label="Calibration steps">
+      <h2 class="calibration-stepper__title">Steps</h2>
+      <ol class="calibration-stepper__list">
+        <li>
+          <h3>1. Position camera</h3>
+          <p>Ensure the athlete is centered in the frame with full runway visibility.</p>
+        </li>
+        <li>
+          <h3>2. Confirm scale</h3>
+          <p>Place the reference markers at the start and end of the calibration zone.</p>
+        </li>
+        <li>
+          <h3>3. Lock exposure</h3>
+          <p>Freeze auto settings to maintain consistent brightness while capturing frames.</p>
+        </li>
+      </ol>
+      <div class="calibration-stepper__controls">
+        <button type="button" class="calibration-stepper__button" aria-label="Previous step">Back</button>
+        <button type="button" class="calibration-stepper__button calibration-stepper__button--primary" aria-label="Next step">Next</button>
+      </div>
+    </aside>
+    <section class="calibration-filmstrip" aria-label="Captured frames">
+      <div class="calibration-filmstrip__header">
+        <h2 class="calibration-filmstrip__title">Filmstrip</h2>
+        <p class="calibration-filmstrip__hint">Scroll to review captured frames.</p>
+      </div>
+      <div class="calibration-filmstrip__scroller" role="list">
+        <button type="button" role="listitem" class="calibration-filmstrip__frame calibration-filmstrip__frame--active" aria-label="Frame 1 selected">Frame 1</button>
+        <button type="button" role="listitem" class="calibration-filmstrip__frame" aria-label="Frame 2">Frame 2</button>
+        <button type="button" role="listitem" class="calibration-filmstrip__frame" aria-label="Frame 3">Frame 3</button>
+        <button type="button" role="listitem" class="calibration-filmstrip__frame" aria-label="Frame 4">Frame 4</button>
+        <button type="button" role="listitem" class="calibration-filmstrip__frame" aria-label="Frame 5">Frame 5</button>
+      </div>
+    </section>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add a calibration workspace page that prioritises the viewport alongside a compact stepper
- implement responsive grid styling that keeps the filmstrip docked below the viewport
- document the layout shift in REPORT-CalibLayout.md

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da53c30918832ba20e615ab3f899e9