### PR TITLE
Add localized landing page with interactive contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title data-i18n="meta.title">Digitalagentur Onkel Tom</title>
+    <meta name="description" data-i18n="meta.description" content="Digitale Strategien, die begeistern." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=typography,forms"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+            },
+            colors: {
+              primary: {
+                DEFAULT: '#1d4ed8',
+                foreground: '#f8fafc',
+              },
+              surface: '#ffffff',
+              background: '#f1f5f9',
+            },
+            boxShadow: {
+              soft: '0 20px 45px -20px rgba(15, 23, 42, 0.35)',
+            },
+          },
+        },
+      };
+    </script>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='16' fill='%231d4ed8'/><text x='16' y='21' font-family='Inter' font-size='16' fill='white' text-anchor='middle'>OT</text></svg>" />
+  </head>
+  <body class="bg-background text-slate-900 antialiased">
+    <header class="sticky top-0 z-40 border-b border-slate-200/50 bg-white/80 backdrop-blur">
+      <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+        <a href="#hero" class="flex items-center gap-2 text-lg font-semibold text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary">
+          <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground shadow-sm" aria-hidden="true">OT</span>
+          <span data-i18n="nav.brand">Onkel Tom Digital</span>
+        </a>
+        <nav class="hidden items-center gap-6 text-sm font-medium text-slate-700 md:flex">
+          <a href="#services" class="transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" data-i18n="nav.services">Leistungen</a>
+          <a href="#process" class="transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" data-i18n="nav.process">Ablauf</a>
+          <a href="#stats" class="transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" data-i18n="nav.stats">Ergebnisse</a>
+          <a href="#testimonials" class="transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" data-i18n="nav.testimonials">Stimmen</a>
+          <a href="#contact" class="transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" data-i18n="nav.contact">Kontakt</a>
+        </nav>
+        <div class="flex items-center gap-3">
+          <button id="localeToggle" class="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" type="button" data-i18n="nav.toggle">
+            EN
+          </button>
+          <a href="#contact" class="hidden rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-soft transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white md:inline-flex" data-i18n="nav.cta">Projekt starten</a>
+        </div>
+      </div>
+    </header>
+    <main>
+      <section id="hero" class="relative overflow-hidden bg-surface">
+        <div class="mx-auto grid max-w-6xl gap-10 px-6 py-20 md:grid-cols-[1.1fr_0.9fr] md:py-28">
+          <div class="flex flex-col gap-8">
+            <div class="inline-flex items-center gap-2 self-start rounded-full border border-primary/20 bg-primary/10 px-4 py-1 text-sm font-medium text-primary">
+              <span class="inline-block h-2 w-2 rounded-full bg-primary" aria-hidden="true"></span>
+              <span data-i18n="hero.badge">Digitalagentur aus Berlin</span>
+            </div>
+            <div class="space-y-6">
+              <h1 class="text-4xl font-bold tracking-tight text-slate-900 sm:text-5xl" data-i18n="hero.title">Strategien, die morgen Bestand haben.</h1>
+              <p class="text-lg text-slate-600 sm:text-xl" data-i18n="hero.subtitle">Wir begleiten ambitionierte Marken vom ersten Funken bis zur performanten Kampagne.</p>
+            </div>
+            <div class="flex flex-col gap-3 sm:flex-row">
+              <button id="heroCta" class="inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow-soft transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface" type="button" data-i18n="hero.primaryCta">Kostenloses Erstgespräch</button>
+              <a id="heroVideo" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" class="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface" data-video-target="https://www.youtube.com/watch?v=dQw4w9WgXcQ" data-i18n="hero.secondaryCta">
+                Video ansehen
+              </a>
+            </div>
+            <div class="grid gap-6 sm:grid-cols-3">
+              <div class="rounded-3xl bg-white p-6 shadow-soft">
+                <p class="text-sm font-medium text-slate-500" data-i18n="hero.stats.clientsLabel">Betreute Kunden</p>
+                <p class="text-3xl font-semibold text-slate-900"><span data-i18n="hero.stats.clients" data-format="number" data-format-value="48">48</span>+</p>
+              </div>
+              <div class="rounded-3xl bg-white p-6 shadow-soft">
+                <p class="text-sm font-medium text-slate-500" data-i18n="hero.stats.revenueLabel">Zusätzlicher Umsatz</p>
+                <p class="text-3xl font-semibold text-slate-900"><span data-i18n="hero.stats.revenue" data-format="currency" data-format-value="1250000" data-format-options='{"style":"currency","currency":"EUR"}'>1.250.000 €</span></p>
+              </div>
+              <div class="rounded-3xl bg-white p-6 shadow-soft">
+                <p class="text-sm font-medium text-slate-500" data-i18n="hero.stats.updatedLabel">Zuletzt aktualisiert</p>
+                <p class="text-3xl font-semibold text-slate-900"><span data-i18n="hero.stats.updated" data-format="date" data-format-value="2024-04-12">12.04.2024</span></p>
+              </div>
+            </div>
+          </div>
+          <div class="flex items-center justify-center">
+            <div class="relative w-full max-w-md overflow-hidden rounded-3xl bg-gradient-to-br from-primary to-indigo-500 p-1 shadow-soft">
+              <div class="rounded-[26px] bg-white p-8 shadow-inner">
+                <h2 class="text-xl font-semibold text-slate-900" data-i18n="hero.card.title">Insights in Echtzeit</h2>
+                <p class="mt-3 text-sm text-slate-600" data-i18n="hero.card.copy">Live-Dashboards zeigen Kampagnenstatus, Benchmarks und Handlungsempfehlungen.</p>
+                <ul class="mt-6 space-y-3 text-sm text-slate-600">
+                  <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-2 w-2 rounded-full bg-primary" aria-hidden="true"></span><span data-i18n="hero.card.pointOne">Automatisierte Performance-Alerts</span></li>
+                  <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-2 w-2 rounded-full bg-primary" aria-hidden="true"></span><span data-i18n="hero.card.pointTwo">Segmentierte Personas in Sekunden</span></li>
+                  <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-2 w-2 rounded-full bg-primary" aria-hidden="true"></span><span data-i18n="hero.card.pointThree">Transparente Zielvereinbarungen</span></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section id="services" class="bg-background">
+        <div class="mx-auto max-w-6xl px-6 py-20 sm:py-24">
+          <div class="mx-auto max-w-2xl text-center">
+            <h2 class="text-3xl font-semibold text-slate-900 sm:text-4xl" data-i18n="services.heading">Wachstum über den gesamten Funnel.</h2>
+            <p class="mt-4 text-lg text-slate-600" data-i18n="services.lead">Unsere spezialisierten Teams orchestrieren messbare Kampagnen, die den Unterschied machen.</p>
+          </div>
+          <div class="mt-12 grid gap-6 md:grid-cols-3">
+            <article class="rounded-3xl bg-white p-8 shadow-soft">
+              <h3 class="text-xl font-semibold text-slate-900" data-i18n="services.strategy.title">Strategische Roadmaps</h3>
+              <p class="mt-3 text-sm text-slate-600" data-i18n="services.strategy.copy">Marktrecherche, Positionierung und Zielarchitekturen, die sich auszahlen.</p>
+              <a href="#process" class="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:translate-x-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" data-i18n="services.strategy.cta">So planen wir</a>
+            </article>
+            <article class="rounded-3xl bg-white p-8 shadow-soft">
+              <h3 class="text-xl font-semibold text-slate-900" data-i18n="services.creative.title">Kreative Produktion</h3>
+              <p class="mt-3 text-sm text-slate-600" data-i18n="services.creative.copy">Content-Serien, Motion Design und Landingpages, die konvertieren.</p>
+              <a href="#portfolio" class="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:translate-x-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" data-i18n="services.creative.cta">Ergebnisse ansehen</a>
+            </article>
+            <article class="rounded-3xl bg-white p-8 shadow-soft">
+              <h3 class="text-xl font-semibold text-slate-900" data-i18n="services.performance.title">Performance &amp; Automation</h3>
+              <p class="mt-3 text-sm text-slate-600" data-i18n="services.performance.copy">KI-gestützte Optimierung mit klaren KPIs und automatisierten Journeys.</p>
+              <a href="#stats" class="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:translate-x-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" data-i18n="services.performance.cta">KPIs entdecken</a>
+            </article>
+          </div>
+        </div>
+      </section>
+      <section id="process" class="bg-surface">
+        <div class="mx-auto max-w-6xl px-6 py-20 sm:py-24">
+          <div class="mx-auto max-w-2xl text-center">
+            <h2 class="text-3xl font-semibold text-slate-900 sm:text-4xl" data-i18n="process.heading">Ein klarer Ablauf für mutige Teams.</h2>
+            <p class="mt-4 text-lg text-slate-600" data-i18n="process.lead">Transparente Sprints, die schnell zu Ergebnissen führen.</p>
+          </div>
+          <div class="mt-12 grid gap-6 md:grid-cols-4">
+            <article class="rounded-3xl bg-white p-6 text-left shadow-soft">
+              <div class="text-sm font-semibold uppercase tracking-wide text-primary" data-i18n="process.discovery.step">1. Discovery</div>
+              <h3 class="mt-3 text-lg font-semibold text-slate-900" data-i18n="process.discovery.title">Vision schärfen</h3>
+              <p class="mt-2 text-sm text-slate-600" data-i18n="process.discovery.copy">Workshops, Datenanalyse und Zieldefinition mit allen Stakeholdern.</p>
+            </article>
+            <article class="rounded-3xl bg-white p-6 text-left shadow-soft">
+              <div class="text-sm font-semibold uppercase tracking-wide text-primary" data-i18n="process.prototype.step">2. Prototyp</div>
+              <h3 class="mt-3 text-lg font-semibold text-slate-900" data-i18n="process.prototype.title">Erlebnisse testen</h3>
+              <p class="mt-2 text-sm text-slate-600" data-i18n="process.prototype.copy">Low-Fidelity-Prototypen validieren Ideen mit echten Nutzer:innen.</p>
+            </article>
+            <article class="rounded-3xl bg-white p-6 text-left shadow-soft">
+              <div class="text-sm font-semibold uppercase tracking-wide text-primary" data-i18n="process.launch.step">3. Launch</div>
+              <h3 class="mt-3 text-lg font-semibold text-slate-900" data-i18n="process.launch.title">Live gehen</h3>
+              <p class="mt-2 text-sm text-slate-600" data-i18n="process.launch.copy">Kampagnen, Automationen und Tracking gehen kontrolliert live.</p>
+            </article>
+            <article class="rounded-3xl bg-white p-6 text-left shadow-soft">
+              <div class="text-sm font-semibold uppercase tracking-wide text-primary" data-i18n="process.optimize.step">4. Scale</div>
+              <h3 class="mt-3 text-lg font-semibold text-slate-900" data-i18n="process.optimize.title">Erfolge multiplizieren</h3>
+              <p class="mt-2 text-sm text-slate-600" data-i18n="process.optimize.copy">Kontinuierliche Experimente liefern bessere Ergebnisse.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+      <section id="stats" class="bg-background">
+        <div class="mx-auto max-w-6xl px-6 py-20 sm:py-24">
+          <div class="mx-auto max-w-2xl text-center">
+            <h2 class="text-3xl font-semibold text-slate-900 sm:text-4xl" data-i18n="stats.heading">Beweisbare Resultate für Ihre Stakeholder.</h2>
+            <p class="mt-4 text-lg text-slate-600" data-i18n="stats.lead">Wir liefern belastbare Zahlen und transparente Lernkurven.</p>
+          </div>
+          <div class="mt-12 grid gap-6 md:grid-cols-3">
+            <article class="rounded-3xl bg-white p-8 text-center shadow-soft">
+              <p class="text-4xl font-bold text-primary"><span data-i18n="stats.roi" data-format="percent" data-format-value="0.42" data-format-options='{"style":"percent","maximumFractionDigits":0}'>42%</span></p>
+              <p class="mt-3 text-sm text-slate-600" data-i18n="stats.roiLabel">Ø-ROAS Steigerung nach 90 Tagen</p>
+            </article>
+            <article class="rounded-3xl bg-white p-8 text-center shadow-soft">
+              <p class="text-4xl font-bold text-primary"><span data-i18n="stats.launchTime" data-format="number" data-format-value="6">6</span> <span data-i18n="stats.launchTimeSuffix">Wochen</span></p>
+              <p class="mt-3 text-sm text-slate-600" data-i18n="stats.launchTimeLabel">Von Kick-off bis Kampagnenstart</p>
+            </article>
+            <article class="rounded-3xl bg-white p-8 text-center shadow-soft">
+              <p class="text-4xl font-bold text-primary"><span data-i18n="stats.nps" data-format="number" data-format-value="72">72</span></p>
+              <p class="mt-3 text-sm text-slate-600" data-i18n="stats.npsLabel">Net Promoter Score unserer Partner:innen</p>
+            </article>
+          </div>
+        </div>
+      </section>
+      <section id="portfolio" class="bg-surface">
+        <div class="mx-auto max-w-6xl px-6 py-20 sm:py-24">
+          <div class="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+            <div class="max-w-2xl">
+              <h2 class="text-3xl font-semibold text-slate-900 sm:text-4xl" data-i18n="portfolio.heading">Kampagnen, die Gesprächsthema wurden.</h2>
+              <p class="mt-4 text-lg text-slate-600" data-i18n="portfolio.lead">Ein Auszug unserer jüngsten Projekte, die Marken sichtbar gemacht haben.</p>
+            </div>
+            <button id="portfolioCta" class="self-start rounded-full border border-primary bg-primary/10 px-6 py-3 text-sm font-semibold text-primary transition hover:bg-primary hover:text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface" type="button" data-i18n="portfolio.cta">Weitere Cases anfragen</button>
+          </div>
+          <div class="mt-12 grid gap-6 md:grid-cols-3">
+            <article class="rounded-3xl bg-white p-6 shadow-soft">
+              <h3 class="text-lg font-semibold text-slate-900" data-i18n="portfolio.caseOne.title">Fintech: Conversion verdoppelt</h3>
+              <p class="mt-3 text-sm text-slate-600">
+                <span class="mr-1 inline-block" data-i18n="portfolio.caseOne.copyPrefix">Durch Funnel-Automationen stieg der Umsatz des Start-ups um</span>
+                <span data-i18n="portfolio.caseOne.impact" data-format="percent" data-format-value="0.36" data-format-options='{"style":"percent","maximumFractionDigits":0}'>36%</span>
+                <span class="ml-1 inline-block" data-i18n="portfolio.caseOne.copySuffix">.</span>
+              </p>
+            </article>
+            <article class="rounded-3xl bg-white p-6 shadow-soft">
+              <h3 class="text-lg font-semibold text-slate-900" data-i18n="portfolio.caseTwo.title">Retail: Community aktiviert</h3>
+              <p class="mt-3 text-sm text-slate-600">
+                <span class="mr-1 inline-block" data-i18n="portfolio.caseTwo.copyPrefix">Social-Commerce-Kampagnen steigerten die Bestellungen um</span>
+                <span data-i18n="portfolio.caseTwo.impact" data-format="percent" data-format-value="0.54" data-format-options='{"style":"percent","maximumFractionDigits":0}'>54%</span>
+                <span class="ml-1 inline-block" data-i18n="portfolio.caseTwo.copySuffix">.</span>
+              </p>
+            </article>
+            <article class="rounded-3xl bg-white p-6 shadow-soft">
+              <h3 class="text-lg font-semibold text-slate-900" data-i18n="portfolio.caseThree.title">Healthcare: Vertrauen gewonnen</h3>
+              <p class="mt-3 text-sm text-slate-600">
+                <span class="mr-1 inline-block" data-i18n="portfolio.caseThree.copyPrefix">Personalisierte Journeys erhöhten den NPS auf</span>
+                <span data-i18n="portfolio.caseThree.impact" data-format="number" data-format-value="68">68</span>
+                <span class="ml-1 inline-block" data-i18n="portfolio.caseThree.copySuffix">.</span>
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+      <section id="testimonials" class="bg-background">
+        <div class="mx-auto max-w-6xl px-6 py-20 sm:py-24">
+          <div class="mx-auto max-w-2xl text-center">
+            <h2 class="text-3xl font-semibold text-slate-900 sm:text-4xl" data-i18n="testimonials.heading">Partnerschaften, die inspirieren.</h2>
+            <p class="mt-4 text-lg text-slate-600" data-i18n="testimonials.lead">Feedback von Marken, die mit uns neue Standards setzen.</p>
+          </div>
+          <div class="mt-12 grid gap-6 md:grid-cols-3">
+            <article class="flex h-full flex-col rounded-3xl bg-white p-6 shadow-soft">
+              <p class="text-sm text-slate-600" data-i18n="testimonials.first.quote">»Onkel Tom hat unser Team in Rekordzeit befähigt, datenbasierte Entscheidungen zu treffen.«</p>
+              <div class="mt-6">
+                <p class="text-sm font-semibold text-slate-900" data-i18n="testimonials.first.name">Elena Gruber</p>
+                <p class="text-xs text-slate-500" data-i18n="testimonials.first.role">CMO, FlowPay</p>
+              </div>
+            </article>
+            <article class="flex h-full flex-col rounded-3xl bg-white p-6 shadow-soft">
+              <p class="text-sm text-slate-600" data-i18n="testimonials.second.quote">»Von der Idee bis zur Auswertung fühlten wir uns jederzeit abgeholt und informiert.«</p>
+              <div class="mt-6">
+                <p class="text-sm font-semibold text-slate-900" data-i18n="testimonials.second.name">Malik Aydin</p>
+                <p class="text-xs text-slate-500" data-i18n="testimonials.second.role">Head of Growth, UrbanYard</p>
+              </div>
+            </article>
+            <article class="flex h-full flex-col rounded-3xl bg-white p-6 shadow-soft">
+              <p class="text-sm text-slate-600" data-i18n="testimonials.third.quote">»Selten haben wir eine so klare, empathische Kommunikation erlebt.«</p>
+              <div class="mt-6">
+                <p class="text-sm font-semibold text-slate-900" data-i18n="testimonials.third.name">Anja Keller</p>
+                <p class="text-xs text-slate-500" data-i18n="testimonials.third.role">Direktorin Kommunikation, HealthFirst</p>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+      <section id="faq" class="bg-surface">
+        <div class="mx-auto max-w-6xl px-6 py-20 sm:py-24">
+          <div class="mx-auto max-w-3xl">
+            <h2 class="text-3xl font-semibold text-slate-900 sm:text-4xl" data-i18n="faq.heading">Antworten auf häufige Fragen.</h2>
+            <p class="mt-4 text-lg text-slate-600" data-i18n="faq.lead">Transparenz ist uns wichtig. Hier finden Sie kompakte Antworten.</p>
+            <div class="mt-10 space-y-6">
+              <details class="group rounded-3xl bg-white p-6 shadow-soft">
+                <summary class="flex cursor-pointer items-center justify-between text-left text-sm font-semibold text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" data-i18n="faq.one.question">Wie schnell können wir starten?</summary>
+                <p class="mt-4 text-sm text-slate-600" data-i18n="faq.one.answer">Nach dem Kick-off legen wir innerhalb von zehn Werktagen mit ersten Maßnahmen los.</p>
+              </details>
+              <details class="group rounded-3xl bg-white p-6 shadow-soft">
+                <summary class="flex cursor-pointer items-center justify-between text-left text-sm font-semibold text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" data-i18n="faq.two.question">Welche Branchen betreut ihr?</summary>
+                <p class="mt-4 text-sm text-slate-600" data-i18n="faq.two.answer">Wir arbeiten mit Tech-, Retail-, Gesundheits- und Bildungsunternehmen zusammen.</p>
+              </details>
+              <details class="group rounded-3xl bg-white p-6 shadow-soft">
+                <summary class="flex cursor-pointer items-center justify-between text-left text-sm font-semibold text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" data-i18n="faq.three.question">Wie sehen eure Preise aus?</summary>
+                <p class="mt-4 text-sm text-slate-600" data-i18n="faq.three.answer">Wir erstellen modulare Angebote ab 4.500 € monatlich – abgestimmt auf Ihre Ziele.</p>
+              </details>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section id="contact" class="bg-background">
+        <div class="mx-auto max-w-4xl px-6 py-20 sm:py-24">
+          <div class="rounded-3xl bg-white p-10 shadow-soft">
+            <div class="space-y-4 text-center">
+              <h2 class="text-3xl font-semibold text-slate-900" data-i18n="contact.heading">Lassen Sie uns sprechen.</h2>
+              <p class="text-lg text-slate-600" data-i18n="contact.lead">Erzählen Sie uns von Ihren Wachstumszielen – wir melden uns innerhalb eines Werktags.</p>
+            </div>
+            <form id="contactForm" class="mt-10 space-y-6" action="https://formspree.io/f/mnqekjwn" method="POST">
+              <div>
+                <label class="block text-sm font-medium text-slate-700" for="name" data-i18n="contact.form.nameLabel">Name</label>
+                <input id="name" name="name" type="text" required class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 shadow-inner focus:border-primary focus:bg-white focus:outline-none focus:ring-2 focus:ring-primary" data-i18n-placeholder="contact.form.namePlaceholder" placeholder="Vor- und Nachname" />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-slate-700" for="email" data-i18n="contact.form.emailLabel">E-Mail</label>
+                <input id="email" name="email" type="email" required class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 shadow-inner focus:border-primary focus:bg-white focus:outline-none focus:ring-2 focus:ring-primary" data-i18n-placeholder="contact.form.emailPlaceholder" placeholder="name@unternehmen.de" />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-slate-700" for="company" data-i18n="contact.form.companyLabel">Unternehmen</label>
+                <input id="company" name="company" type="text" class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 shadow-inner focus:border-primary focus:bg-white focus:outline-none focus:ring-2 focus:ring-primary" data-i18n-placeholder="contact.form.companyPlaceholder" placeholder="Firmenname" />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-slate-700" for="message" data-i18n="contact.form.messageLabel">Projektbeschreibung</label>
+                <textarea id="message" name="message" rows="4" required class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 shadow-inner focus:border-primary focus:bg-white focus:outline-none focus:ring-2 focus:ring-primary" data-i18n-placeholder="contact.form.messagePlaceholder" placeholder="Welche Ziele verfolgen Sie?" ></textarea>
+              </div>
+              <div class="flex items-start gap-3">
+                <input id="privacy" name="privacy" type="checkbox" required class="mt-1 h-5 w-5 rounded border border-slate-300 text-primary focus:ring-primary" />
+                <label class="text-sm text-slate-600" for="privacy" data-i18n="contact.form.privacy">Ich stimme der Verarbeitung meiner Daten gemäß Datenschutzhinweisen zu.</label>
+              </div>
+              <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <button class="inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow-soft transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white" type="submit" data-i18n="contact.form.submit">Nachricht senden</button>
+                <p id="formStatus" class="text-sm text-slate-500" data-i18n="contact.form.statusIdle">Wir antworten innerhalb eines Werktags.</p>
+              </div>
+            </form>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="bg-slate-900 py-12 text-slate-300">
+      <div class="mx-auto flex max-w-6xl flex-col gap-6 px-6 md:flex-row md:items-center md:justify-between">
+        <p class="text-sm">
+          <span class="mr-1 inline-block" data-i18n="footer.copyPrefix">©</span>
+          <span class="mr-1 inline-block" data-i18n="footer.year" data-format="date" data-format-value="2024-01-01" data-format-options='{"year":"numeric"}'>2024</span>
+          <span class="inline-block" data-i18n="footer.copySuffix">Onkel Tom Digitalagentur. Alle Rechte vorbehalten.</span>
+        </p>
+        <div class="flex gap-6 text-sm">
+          <a href="mailto:hallo@onkeltom.de" class="transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900" data-i18n="footer.mail">hallo@onkeltom.de</a>
+          <a href="#privacy" class="transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900" data-i18n="footer.privacy">Datenschutz</a>
+        </div>
+      </div>
+    </footer>
+    <div id="toast" class="pointer-events-none fixed inset-x-0 top-4 flex justify-center px-4 opacity-0 transition-opacity" role="status" aria-live="polite"></div>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,538 @@
+const translations = {
+  de: {
+    'meta.title': 'Digitalagentur Onkel Tom',
+    'meta.description': 'Digitale Strategien, die begeistern.',
+    'nav.brand': 'Onkel Tom Digital',
+    'nav.services': 'Leistungen',
+    'nav.process': 'Ablauf',
+    'nav.stats': 'Ergebnisse',
+    'nav.testimonials': 'Stimmen',
+    'nav.contact': 'Kontakt',
+    'nav.toggle': 'EN',
+    'nav.cta': 'Projekt starten',
+    'hero.badge': 'Digitalagentur aus Berlin',
+    'hero.title': 'Strategien, die morgen Bestand haben.',
+    'hero.subtitle': 'Wir begleiten ambitionierte Marken vom ersten Funken bis zur performanten Kampagne.',
+    'hero.primaryCta': 'Kostenloses Erstgespräch',
+    'hero.secondaryCta': 'Video ansehen',
+    'hero.stats.clientsLabel': 'Betreute Kunden',
+    'hero.stats.clients': '48',
+    'hero.stats.revenueLabel': 'Zusätzlicher Umsatz',
+    'hero.stats.revenue': '1250000',
+    'hero.stats.updatedLabel': 'Zuletzt aktualisiert',
+    'hero.stats.updated': '2024-04-12',
+    'hero.card.title': 'Insights in Echtzeit',
+    'hero.card.copy': 'Live-Dashboards zeigen Kampagnenstatus, Benchmarks und Handlungsempfehlungen.',
+    'hero.card.pointOne': 'Automatisierte Performance-Alerts',
+    'hero.card.pointTwo': 'Segmentierte Personas in Sekunden',
+    'hero.card.pointThree': 'Transparente Zielvereinbarungen',
+    'services.heading': 'Wachstum über den gesamten Funnel.',
+    'services.lead': 'Unsere spezialisierten Teams orchestrieren messbare Kampagnen, die den Unterschied machen.',
+    'services.strategy.title': 'Strategische Roadmaps',
+    'services.strategy.copy': 'Marktrecherche, Positionierung und Zielarchitekturen, die sich auszahlen.',
+    'services.strategy.cta': 'So planen wir',
+    'services.creative.title': 'Kreative Produktion',
+    'services.creative.copy': 'Content-Serien, Motion Design und Landingpages, die konvertieren.',
+    'services.creative.cta': 'Ergebnisse ansehen',
+    'services.performance.title': 'Performance & Automation',
+    'services.performance.copy': 'KI-gestützte Optimierung mit klaren KPIs und automatisierten Journeys.',
+    'services.performance.cta': 'KPIs entdecken',
+    'process.heading': 'Ein klarer Ablauf für mutige Teams.',
+    'process.lead': 'Transparente Sprints, die schnell zu Ergebnissen führen.',
+    'process.discovery.step': '1. Discovery',
+    'process.discovery.title': 'Vision schärfen',
+    'process.discovery.copy': 'Workshops, Datenanalyse und Zieldefinition mit allen Stakeholdern.',
+    'process.prototype.step': '2. Prototyp',
+    'process.prototype.title': 'Erlebnisse testen',
+    'process.prototype.copy': 'Low-Fidelity-Prototypen validieren Ideen mit echten Nutzer:innen.',
+    'process.launch.step': '3. Launch',
+    'process.launch.title': 'Live gehen',
+    'process.launch.copy': 'Kampagnen, Automationen und Tracking gehen kontrolliert live.',
+    'process.optimize.step': '4. Scale',
+    'process.optimize.title': 'Erfolge multiplizieren',
+    'process.optimize.copy': 'Kontinuierliche Experimente liefern bessere Ergebnisse.',
+    'stats.heading': 'Beweisbare Resultate für Ihre Stakeholder.',
+    'stats.lead': 'Wir liefern belastbare Zahlen und transparente Lernkurven.',
+    'stats.roi': '0.42',
+    'stats.roiLabel': 'Ø-ROAS Steigerung nach 90 Tagen',
+    'stats.launchTime': '6',
+    'stats.launchTimeSuffix': 'Wochen',
+    'stats.launchTimeLabel': 'Von Kick-off bis Kampagnenstart',
+    'stats.nps': '72',
+    'stats.npsLabel': 'Net Promoter Score unserer Partner:innen',
+    'portfolio.heading': 'Kampagnen, die Gesprächsthema wurden.',
+    'portfolio.lead': 'Ein Auszug unserer jüngsten Projekte, die Marken sichtbar gemacht haben.',
+    'portfolio.cta': 'Weitere Cases anfragen',
+    'portfolio.caseOne.title': 'Fintech: Conversion verdoppelt',
+    'portfolio.caseOne.copyPrefix': 'Durch Funnel-Automationen stieg der Umsatz des Start-ups um',
+    'portfolio.caseOne.impact': '0.36',
+    'portfolio.caseOne.copySuffix': '.',
+    'portfolio.caseTwo.title': 'Retail: Community aktiviert',
+    'portfolio.caseTwo.copyPrefix': 'Social-Commerce-Kampagnen steigerten die Bestellungen um',
+    'portfolio.caseTwo.impact': '0.54',
+    'portfolio.caseTwo.copySuffix': '.',
+    'portfolio.caseThree.title': 'Healthcare: Vertrauen gewonnen',
+    'portfolio.caseThree.copyPrefix': 'Personalisierte Journeys erhöhten den NPS auf',
+    'portfolio.caseThree.impact': '68',
+    'portfolio.caseThree.copySuffix': '.',
+    'testimonials.heading': 'Partnerschaften, die inspirieren.',
+    'testimonials.lead': 'Feedback von Marken, die mit uns neue Standards setzen.',
+    'testimonials.first.quote': '»Onkel Tom hat unser Team in Rekordzeit befähigt, datenbasierte Entscheidungen zu treffen.«',
+    'testimonials.first.name': 'Elena Gruber',
+    'testimonials.first.role': 'CMO, FlowPay',
+    'testimonials.second.quote': '»Von der Idee bis zur Auswertung fühlten wir uns jederzeit abgeholt und informiert.«',
+    'testimonials.second.name': 'Malik Aydin',
+    'testimonials.second.role': 'Head of Growth, UrbanYard',
+    'testimonials.third.quote': '»Selten haben wir eine so klare, empathische Kommunikation erlebt.«',
+    'testimonials.third.name': 'Anja Keller',
+    'testimonials.third.role': 'Direktorin Kommunikation, HealthFirst',
+    'faq.heading': 'Antworten auf häufige Fragen.',
+    'faq.lead': 'Transparenz ist uns wichtig. Hier finden Sie kompakte Antworten.',
+    'faq.one.question': 'Wie schnell können wir starten?',
+    'faq.one.answer': 'Nach dem Kick-off legen wir innerhalb von zehn Werktagen mit ersten Maßnahmen los.',
+    'faq.two.question': 'Welche Branchen betreut ihr?',
+    'faq.two.answer': 'Wir arbeiten mit Tech-, Retail-, Gesundheits- und Bildungsunternehmen zusammen.',
+    'faq.three.question': 'Wie sehen eure Preise aus?',
+    'faq.three.answer': 'Wir erstellen modulare Angebote ab 4.500 € monatlich – abgestimmt auf Ihre Ziele.',
+    'contact.heading': 'Lassen Sie uns sprechen.',
+    'contact.lead': 'Erzählen Sie uns von Ihren Wachstumszielen – wir melden uns innerhalb eines Werktags.',
+    'contact.form.nameLabel': 'Name',
+    'contact.form.namePlaceholder': 'Vor- und Nachname',
+    'contact.form.emailLabel': 'E-Mail',
+    'contact.form.emailPlaceholder': 'name@unternehmen.de',
+    'contact.form.companyLabel': 'Unternehmen',
+    'contact.form.companyPlaceholder': 'Firmenname',
+    'contact.form.messageLabel': 'Projektbeschreibung',
+    'contact.form.messagePlaceholder': 'Welche Ziele verfolgen Sie?',
+    'contact.form.privacy': 'Ich stimme der Verarbeitung meiner Daten gemäß Datenschutzhinweisen zu.',
+    'contact.form.submit': 'Nachricht senden',
+    'contact.form.statusIdle': 'Wir antworten innerhalb eines Werktags.',
+    'contact.form.statusSending': 'Wir prüfen Ihre Anfrage …',
+    'contact.form.statusSuccess': 'Vielen Dank! Wir melden uns zeitnah.',
+    'contact.form.statusError': 'Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.',
+    'contact.form.toastSuccess': 'Anfrage erfolgreich übermittelt.',
+    'contact.form.toastError': 'Nachricht konnte nicht gesendet werden. Bitte nutzen Sie das E-Mail-Fallback.',
+    'contact.form.mailtoSubject': 'Projektanfrage über onkeltom.de',
+    'footer.copyPrefix': '©',
+    'footer.year': '2024-01-01',
+    'footer.copySuffix': 'Onkel Tom Digitalagentur. Alle Rechte vorbehalten.',
+    'footer.mail': 'hallo@onkeltom.de',
+    'footer.privacy': 'Datenschutz',
+  },
+  en: {
+    'meta.title': 'Onkel Tom Digital Agency',
+    'meta.description': 'Digital strategies that delight.',
+    'nav.brand': 'Onkel Tom Digital',
+    'nav.services': 'Services',
+    'nav.process': 'Process',
+    'nav.stats': 'Results',
+    'nav.testimonials': 'Voices',
+    'nav.contact': 'Contact',
+    'nav.toggle': 'DE',
+    'nav.cta': 'Start a project',
+    'hero.badge': 'Digital agency from Berlin',
+    'hero.title': 'Strategies built to last.',
+    'hero.subtitle': 'We guide ambitious brands from first spark to high-performing campaigns.',
+    'hero.primaryCta': 'Book a free consultation',
+    'hero.secondaryCta': 'Watch video',
+    'hero.stats.clientsLabel': 'Clients guided',
+    'hero.stats.clients': '48',
+    'hero.stats.revenueLabel': 'Additional revenue',
+    'hero.stats.revenue': '1250000',
+    'hero.stats.updatedLabel': 'Last updated',
+    'hero.stats.updated': '2024-04-12',
+    'hero.card.title': 'Insights in real time',
+    'hero.card.copy': 'Live dashboards highlight campaign status, benchmarks, and next steps.',
+    'hero.card.pointOne': 'Automated performance alerts',
+    'hero.card.pointTwo': 'Segmented personas in seconds',
+    'hero.card.pointThree': 'Transparent goal agreements',
+    'services.heading': 'Growth across the entire funnel.',
+    'services.lead': 'Our specialist teams orchestrate measurable campaigns that make the difference.',
+    'services.strategy.title': 'Strategic roadmaps',
+    'services.strategy.copy': 'Market research, positioning, and goal architectures that pay off.',
+    'services.strategy.cta': 'How we plan',
+    'services.creative.title': 'Creative production',
+    'services.creative.copy': 'Content series, motion design, and landing pages that convert.',
+    'services.creative.cta': 'See results',
+    'services.performance.title': 'Performance & automation',
+    'services.performance.copy': 'AI-powered optimization with clear KPIs and automated journeys.',
+    'services.performance.cta': 'Explore KPIs',
+    'process.heading': 'A clear playbook for bold teams.',
+    'process.lead': 'Transparent sprints that deliver quickly.',
+    'process.discovery.step': '1. Discovery',
+    'process.discovery.title': 'Sharpen the vision',
+    'process.discovery.copy': 'Workshops, data analysis, and aligned goals with every stakeholder.',
+    'process.prototype.step': '2. Prototype',
+    'process.prototype.title': 'Test experiences',
+    'process.prototype.copy': 'Low-fidelity prototypes validate ideas with real users.',
+    'process.launch.step': '3. Launch',
+    'process.launch.title': 'Go live',
+    'process.launch.copy': 'Campaigns, automations, and tracking launch with control.',
+    'process.optimize.step': '4. Scale',
+    'process.optimize.title': 'Multiply wins',
+    'process.optimize.copy': 'Continuous experiments keep improving results.',
+    'stats.heading': 'Proof that convinces stakeholders.',
+    'stats.lead': 'We deliver reliable metrics and transparent learning loops.',
+    'stats.roi': '0.42',
+    'stats.roiLabel': 'Avg. ROAS lift after 90 days',
+    'stats.launchTime': '6',
+    'stats.launchTimeSuffix': 'weeks',
+    'stats.launchTimeLabel': 'From kick-off to campaign launch',
+    'stats.nps': '72',
+    'stats.npsLabel': 'Net Promoter Score from our partners',
+    'portfolio.heading': 'Campaigns people talked about.',
+    'portfolio.lead': 'A selection of recent projects that boosted brand visibility.',
+    'portfolio.cta': 'Request more case studies',
+    'portfolio.caseOne.title': 'Fintech: Conversion doubled',
+    'portfolio.caseOne.copyPrefix': 'Automation lifted revenue by',
+    'portfolio.caseOne.impact': '0.36',
+    'portfolio.caseOne.copySuffix': '.',
+    'portfolio.caseTwo.title': 'Retail: Community activated',
+    'portfolio.caseTwo.copyPrefix': 'Social commerce increased orders by',
+    'portfolio.caseTwo.impact': '0.54',
+    'portfolio.caseTwo.copySuffix': '.',
+    'portfolio.caseThree.title': 'Healthcare: Trust regained',
+    'portfolio.caseThree.copyPrefix': 'Personalized journeys raised NPS to',
+    'portfolio.caseThree.impact': '68',
+    'portfolio.caseThree.copySuffix': '.',
+    'testimonials.heading': 'Partnerships that inspire.',
+    'testimonials.lead': 'Feedback from brands setting new standards with us.',
+    'testimonials.first.quote': '“Onkel Tom enabled our team to make data-driven calls in record time.”',
+    'testimonials.first.name': 'Elena Gruber',
+    'testimonials.first.role': 'CMO, FlowPay',
+    'testimonials.second.quote': '“From idea to reporting we felt guided and informed at all times.”',
+    'testimonials.second.name': 'Malik Aydin',
+    'testimonials.second.role': 'Head of Growth, UrbanYard',
+    'testimonials.third.quote': '“We rarely experience communication that is so clear and empathetic.”',
+    'testimonials.third.name': 'Anja Keller',
+    'testimonials.third.role': 'Director of Communications, HealthFirst',
+    'faq.heading': 'Answers to frequent questions.',
+    'faq.lead': 'Transparency matters to us. Find concise answers here.',
+    'faq.one.question': 'How fast can we start?',
+    'faq.one.answer': 'After the kick-off we launch first measures within ten business days.',
+    'faq.two.question': 'Which industries do you serve?',
+    'faq.two.answer': 'We collaborate with technology, retail, healthcare, and education brands.',
+    'faq.three.question': 'What do your fees look like?',
+    'faq.three.answer': 'We design modular retainers from €4,500 per month tailored to your goals.',
+    'contact.heading': "Let's talk.",
+    'contact.lead': 'Tell us about your growth goals – we reply within one business day.',
+    'contact.form.nameLabel': 'Name',
+    'contact.form.namePlaceholder': 'First and last name',
+    'contact.form.emailLabel': 'Email',
+    'contact.form.emailPlaceholder': 'name@company.com',
+    'contact.form.companyLabel': 'Company',
+    'contact.form.companyPlaceholder': 'Company name',
+    'contact.form.messageLabel': 'Project brief',
+    'contact.form.messagePlaceholder': 'What goals are you pursuing?',
+    'contact.form.privacy': 'I agree to the processing of my data according to the privacy notice.',
+    'contact.form.submit': 'Send message',
+    'contact.form.statusIdle': 'We reply within one business day.',
+    'contact.form.statusSending': 'Reviewing your request…',
+    'contact.form.statusSuccess': 'Thank you! We will reach out shortly.',
+    'contact.form.statusError': 'Something went wrong. Please try again.',
+    'contact.form.toastSuccess': 'Request submitted successfully.',
+    'contact.form.toastError': 'Message could not be sent. Please use the email fallback.',
+    'contact.form.mailtoSubject': 'Project inquiry via onkeltom.de',
+    'footer.copyPrefix': '©',
+    'footer.year': '2024-01-01',
+    'footer.copySuffix': 'Onkel Tom Digital Agency. All rights reserved.',
+    'footer.mail': 'hallo@onkeltom.de',
+    'footer.privacy': 'Privacy',
+  },
+};
+
+const supportedLocales = Object.keys(translations);
+const storageKey = 'preferredLocale';
+let currentLocale = 'de';
+let toastTimeout;
+
+const getStoredLocale = () => {
+  try {
+    const stored = window.localStorage.getItem(storageKey);
+    if (stored && supportedLocales.includes(stored)) {
+      return stored;
+    }
+  } catch (error) {
+    console.warn('Locale storage unavailable', error);
+  }
+  return null;
+};
+
+const detectBrowserLocale = () => {
+  const navigatorLocale = (navigator.language || navigator.languages?.[0] || 'de').slice(0, 2).toLowerCase();
+  return supportedLocales.includes(navigatorLocale) ? navigatorLocale : 'de';
+};
+
+const formatWithIntl = (locale, type, value, options) => {
+  if (!value) {
+    return '';
+  }
+  const parsedOptions = options ? JSON.parse(options) : undefined;
+
+  switch (type) {
+    case 'currency':
+    case 'number': {
+      const numericValue = Number(value);
+      if (Number.isNaN(numericValue)) {
+        return value;
+      }
+      return new Intl.NumberFormat(locale, parsedOptions).format(numericValue);
+    }
+    case 'percent': {
+      const numericValue = Number(value);
+      if (Number.isNaN(numericValue)) {
+        return value;
+      }
+      return new Intl.NumberFormat(locale, parsedOptions || { style: 'percent', maximumFractionDigits: 0 }).format(numericValue);
+    }
+    case 'date': {
+      const dateValue = new Date(value);
+      if (Number.isNaN(dateValue.getTime())) {
+        return value;
+      }
+      return new Intl.DateTimeFormat(locale, parsedOptions || { year: 'numeric', month: '2-digit', day: '2-digit' }).format(dateValue);
+    }
+    default:
+      return value;
+  }
+};
+
+const updatePlaceholders = (locale) => {
+  document.querySelectorAll('[data-i18n-placeholder]').forEach((element) => {
+    const { i18nPlaceholder } = element.dataset;
+    if (!i18nPlaceholder) {
+      return;
+    }
+    const translation = translations[locale][i18nPlaceholder];
+    if (translation) {
+      element.setAttribute('placeholder', translation);
+    }
+  });
+};
+
+const translateElement = (element, locale) => {
+  const { i18n: key, format: formatType, formatValue, formatOptions } = element.dataset;
+  if (!key) {
+    return;
+  }
+  const translation = translations[locale][key];
+  if (formatType) {
+    const formatted = formatWithIntl(locale, formatType, formatValue || translation, formatOptions);
+    if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+      element.value = formatted;
+    } else {
+      element.textContent = formatted;
+    }
+    return;
+  }
+
+  if (!translation) {
+    return;
+  }
+
+  if (element.tagName === 'META') {
+    element.setAttribute('content', translation);
+  } else if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    element.value = translation;
+  } else if (element instanceof HTMLTitleElement) {
+    element.textContent = translation;
+    document.title = translation;
+  } else {
+    element.textContent = translation;
+  }
+};
+
+const applyTranslations = (locale) => {
+  const dictionary = translations[locale];
+  if (!dictionary) {
+    return;
+  }
+  document.documentElement.lang = locale;
+  document.querySelectorAll('[data-i18n]').forEach((element) => translateElement(element, locale));
+  updatePlaceholders(locale);
+};
+
+const persistLocale = (locale) => {
+  try {
+    window.localStorage.setItem(storageKey, locale);
+  } catch (error) {
+    console.warn('Locale storage unavailable', error);
+  }
+};
+
+const toggleLocale = () => {
+  const nextLocale = currentLocale === 'de' ? 'en' : 'de';
+  setLocale(nextLocale);
+};
+
+const showToast = (message, variant = 'info') => {
+  const toast = document.getElementById('toast');
+  if (!toast) {
+    return;
+  }
+  const baseClasses = 'pointer-events-auto inline-flex items-center rounded-full px-5 py-2 text-sm font-semibold shadow-soft ring-1 ring-slate-900/10';
+  const variantClasses = {
+    success: 'bg-emerald-500 text-white',
+    error: 'bg-rose-500 text-white',
+    info: 'bg-slate-900 text-white',
+  };
+  toast.innerHTML = `<span class="${baseClasses} ${variantClasses[variant] || variantClasses.info}">${message}</span>`;
+  toast.classList.remove('opacity-0');
+  clearTimeout(toastTimeout);
+  toastTimeout = window.setTimeout(() => {
+    toast.classList.add('opacity-0');
+  }, 3200);
+};
+
+const scrollToTarget = (targetId) => {
+  const target = document.getElementById(targetId);
+  if (!target) {
+    return;
+  }
+  target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+};
+
+const createMailtoFallback = (formData) => {
+  const dictionary = translations[currentLocale];
+  const email = dictionary['footer.mail'] || 'hallo@onkeltom.de';
+  const subject = encodeURIComponent(dictionary['contact.form.mailtoSubject'] || 'Projektanfrage über onkeltom.de');
+  const nameLabel = dictionary['contact.form.nameLabel'] || 'Name';
+  const emailLabel = dictionary['contact.form.emailLabel'] || 'E-Mail';
+  const companyLabel = dictionary['contact.form.companyLabel'] || 'Unternehmen';
+  const messageLabel = dictionary['contact.form.messageLabel'] || 'Projektbeschreibung';
+  const bodyLines = [
+    `${nameLabel}: ${formData.get('name') || ''}`,
+    `${emailLabel}: ${formData.get('email') || ''}`,
+    `${companyLabel}: ${formData.get('company') || ''}`,
+    `${messageLabel}:`,
+    '',
+    formData.get('message') || '',
+  ];
+  const body = encodeURIComponent(bodyLines.join('\n'));
+  return `mailto:${email}?subject=${subject}&body=${body}`;
+};
+
+const setStatusMessage = (statusElement, locale, key) => {
+  if (!statusElement) {
+    return;
+  }
+  statusElement.dataset.statusKey = key;
+  const message = translations[locale][key];
+  if (message) {
+    statusElement.textContent = message;
+  }
+};
+
+const handleFormSubmission = () => {
+  const form = document.getElementById('contactForm');
+  const statusElement = document.getElementById('formStatus');
+  if (!form || !statusElement) {
+    return;
+  }
+
+  const submitButton = form.querySelector('[type="submit"]');
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const formData = new FormData(form);
+    setStatusMessage(statusElement, currentLocale, 'contact.form.statusSending');
+    if (submitButton instanceof HTMLButtonElement) {
+      submitButton.disabled = true;
+      submitButton.classList.add('opacity-70');
+    }
+
+    const endpoint = form.getAttribute('action');
+    const payload = Object.fromEntries(formData.entries());
+
+    try {
+      const response = await fetch(endpoint || '', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error('Form submission failed');
+      }
+
+      setStatusMessage(statusElement, currentLocale, 'contact.form.statusSuccess');
+      showToast(translations[currentLocale]['contact.form.toastSuccess'], 'success');
+      form.reset();
+    } catch (error) {
+      console.error('Form submission error', error);
+      setStatusMessage(statusElement, currentLocale, 'contact.form.statusError');
+      showToast(translations[currentLocale]['contact.form.toastError'], 'error');
+      window.location.href = createMailtoFallback(formData);
+    } finally {
+      if (submitButton instanceof HTMLButtonElement) {
+        submitButton.disabled = false;
+        submitButton.classList.remove('opacity-70');
+      }
+    }
+  });
+};
+
+const bindInteractions = () => {
+  const heroCta = document.getElementById('heroCta');
+  const portfolioCta = document.getElementById('portfolioCta');
+  const heroVideo = document.getElementById('heroVideo');
+
+  heroCta?.addEventListener('click', () => scrollToTarget('contact'));
+  portfolioCta?.addEventListener('click', () => scrollToTarget('contact'));
+  heroVideo?.addEventListener('click', (event) => {
+    event.preventDefault();
+    const videoUrl = heroVideo.dataset.videoTarget || heroVideo.getAttribute('href');
+    if (videoUrl) {
+      window.open(videoUrl, '_blank', 'noopener');
+    }
+  });
+};
+
+const initializeLocaleToggle = () => {
+  const toggleButton = document.getElementById('localeToggle');
+  if (!toggleButton) {
+    return;
+  }
+  toggleButton.addEventListener('click', toggleLocale);
+};
+
+const updateStatusForLocale = () => {
+  const statusElement = document.getElementById('formStatus');
+  if (!statusElement) {
+    return;
+  }
+  const { statusKey = 'contact.form.statusIdle' } = statusElement.dataset;
+  setStatusMessage(statusElement, currentLocale, statusKey);
+};
+
+const setLocale = (locale) => {
+  currentLocale = supportedLocales.includes(locale) ? locale : 'de';
+  applyTranslations(currentLocale);
+  updateStatusForLocale();
+  persistLocale(currentLocale);
+};
+
+const init = () => {
+  const storedLocale = getStoredLocale();
+  currentLocale = storedLocale || detectBrowserLocale();
+  applyTranslations(currentLocale);
+  updateStatusForLocale();
+  initializeLocaleToggle();
+  bindInteractions();
+  handleFormSubmission();
+};
+
+window.addEventListener('DOMContentLoaded', () => {
+  init();
+});
+
+window.addEventListener('storage', (event) => {
+  if (event.key === storageKey && event.newValue && supportedLocales.includes(event.newValue)) {
+    setLocale(event.newValue);
+  }
+});
+
+export {};


### PR DESCRIPTION
## Summary
- create a responsive landing page with sticky navigation, Tailwind styling, and fully localized copy
- implement translation utilities, locale persistence, and CTA bindings for smooth scrolling and video launch
- add contact form submission with Formspree POST handling, toast feedback, and mailto fallback

## Testing
- no automated tests (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68e657c7fb50832b9511cd8ee947c2ce